### PR TITLE
selectedのデータ取り出しができない問題

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,7 +5,7 @@
     </p>
     <b-tabs>
       <b-tab-item label="選択した機種の詳細">
-        <p>{{ selected }}</p>
+        <p>{{ selected ? selected.model_name : null }}</p>
       </b-tab-item>
 
       <b-tab-item label="端末一覧">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,8 +13,8 @@
           :data="contents"
           :columns="columns"
           :selected.sync="selected"
-          focusable>
-        </b-table>
+          focusable
+        />
       </b-tab-item>
     </b-tabs>
   </section>


### PR DESCRIPTION
# エラーの原因
axiosで取得し終わるまえに `selected.model_name` を呼んでいたため、undefind になっていたのだと思う。
三項演算子で、データが取得できるまでは`null`を返し、取得できた場合に表示するようにすることで対応した。

ついでに、ESLintでwarning(黄色い文字)が出ていたので、以下のコマンドで解消した。

```sh
$ ./node_modules/.bin/eslint pages/index.vue --fix
```